### PR TITLE
feat: add cluster autoscaler

### DIFF
--- a/chart/templates/cluster-autoscaler.yaml
+++ b/chart/templates/cluster-autoscaler.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ .Release.Name }}-cert-manager
+  name: {{ .Release.Name }}-cluster-autoscaler
   namespace: {{ .Values.argoNamespace }}
   finalizers:
     - resources-finalizer.argocd.argoproj.io

--- a/chart/templates/cluster-autoscaler.yaml
+++ b/chart/templates/cluster-autoscaler.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.clusterAutoscaler.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ .Release.Name }}-cert-manager
+  namespace: {{ .Values.argoNamespace }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://kubernetes.github.io/autoscaler
+    chart: cluster-autoscaler
+    targetRevision: {{ .Values.clusterAutoscaler.targetRevision | quote }}
+    helm:
+      releaseName: cluster-autoscaler
+      version: v3
+      {{- with .Values.clusterAutoscaler.values }}
+      values: |
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cluster-autoscaler
+  syncPolicy:
+  {{- toYaml .Values.clusterAutoscaler.syncPolicy | nindent 4 }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -195,6 +195,36 @@ pvcAutoresizer:
     args:
       prometheusURL: http://kube-prometheus-stack-prometheus.kube-prometheus-stack
       interval: 10s
+clusterAutoscaler:
+  enabled: false
+  targetRevision: ""
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  values:
+    # hardcode aws values and fields, because other hosted k8s platforms won't
+    # require the cluster autoscaler
+    cloudProvider: aws
+    awsRegion: replaceme
+    autoDiscovery:
+      clusterName: replaceme
+    rbac:
+      serviceAccount:
+        annotations: {}
+          # eks.amazonaws.com/role-arn: arn:aws:iam::account-id:role/iam-role-name
+        # hardcode service account name to make IRSA configuration simpler
+        name: "cluster-autoscaler"
 sentry:
   enabled: false
   targetRevision: "~13.1.0"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -44,7 +44,7 @@ certManager:
     dnsNames: []
 clusterAutoscaler:
   enabled: false
-  targetRevision: ""
+  targetRevision: "~9.16.1"
   syncPolicy:
     automated:
       prune: true

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -42,6 +42,36 @@ certManager:
       - server auth
       - client auth
     dnsNames: []
+clusterAutoscaler:
+  enabled: false
+  targetRevision: ""
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  values:
+    # hardcode aws values and fields, because other hosted k8s platforms won't
+    # require the cluster autoscaler
+    cloudProvider: aws
+    awsRegion: replaceme
+    autoDiscovery:
+      clusterName: replaceme
+    rbac:
+      serviceAccount:
+        annotations: {}
+          # eks.amazonaws.com/role-arn: arn:aws:iam::account-id:role/iam-role-name
+        # hardcode service account name to make IRSA configuration simpler
+        name: "cluster-autoscaler"
 contour:
   enabled: true
   targetRevision: "~7.3.10"
@@ -195,36 +225,6 @@ pvcAutoresizer:
     args:
       prometheusURL: http://kube-prometheus-stack-prometheus.kube-prometheus-stack
       interval: 10s
-clusterAutoscaler:
-  enabled: false
-  targetRevision: ""
-  syncPolicy:
-    automated:
-      prune: true
-      selfHeal: true
-    syncOptions:
-      - CreateNamespace=true
-      - PrunePropagationPolicy=foreground
-      - PruneLast=true
-    retry:
-      limit: 5
-      backoff:
-        duration: 5s
-        factor: 2
-        maxDuration: 3m
-  values:
-    # hardcode aws values and fields, because other hosted k8s platforms won't
-    # require the cluster autoscaler
-    cloudProvider: aws
-    awsRegion: replaceme
-    autoDiscovery:
-      clusterName: replaceme
-    rbac:
-      serviceAccount:
-        annotations: {}
-          # eks.amazonaws.com/role-arn: arn:aws:iam::account-id:role/iam-role-name
-        # hardcode service account name to make IRSA configuration simpler
-        name: "cluster-autoscaler"
 sentry:
   enabled: false
   targetRevision: "~13.1.0"


### PR DESCRIPTION
added aws specific fields and values to guide configuration in aws
clusters. this shouldn't cause conflict with other cloud providers
because most of them manage the cluster autoscaler for you.

left the IRSA annotation commented because there are other means of
configuring authentication to AWS.