### PR TITLE
fix: Linkerd uses helm template commands to generate certs. This happ…

### DIFF
--- a/chart/templates/linkerd.yaml
+++ b/chart/templates/linkerd.yaml
@@ -24,4 +24,8 @@ spec:
     namespace: linkerd
   syncPolicy:
   {{- toYaml .Values.linkerd.syncPolicy | nindent 4 }}
+  {{- with .Values.linkerd.ignoreDifferences }}
+  ignoreDifferences:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -194,6 +194,52 @@ linkerd:
   values:
     identityTrustAnchorsPEM: |
     installNamespace: false
+  ignoreDifferences:
+    - group: batch
+      jsonPointers:
+        - /spec/schedule
+      kind: CronJob
+      name: linkerd-heartbeat
+    - jsonPointers:
+        - /data/tls.crt
+        - /data/tls.key
+      kind: Secret
+      name: linkerd-policy-validator-k8s-tls
+    - jsonPointers:
+        - /data/tls.crt
+        - /data/tls.key
+      kind: Secret
+      name: linkerd-proxy-injector-k8s-tls
+    - jsonPointers:
+        - /data/tls.crt
+        - /data/tls.key
+      kind: Secret
+      name: linkerd-sp-validator-k8s-tls
+    - group: admissionregistration.k8s.io
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+      kind: MutatingWebhookConfiguration
+      name: linkerd-proxy-injector-webhook-config
+    - group: admissionregistration.k8s.io
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+      kind: ValidatingWebhookConfiguration
+      name: linkerd-policy-validator-webhook-config
+    - group: admissionregistration.k8s.io
+      jqPathExpressions:
+        - .webhooks[]?.clientConfig.caBundle
+      kind: ValidatingWebhookConfiguration
+      name: linkerd-sp-validator-webhook-config
+    - group: apps
+      jqPathExpressions:
+        - .spec.template.metadata.annotations."checksum/config"
+      kind: Deployment
+      name: linkerd-destination
+    - group: apps
+      jqPathExpressions:
+        - .spec.template.metadata.annotations."checksum/config"
+      kind: Deployment
+      name: linkerd-proxy-injector
 # run `linkerd check` after deployment to make sure viz is working. If checks fail, delete all the pods in the `linkerd-viz` namespace and once they're all healthy again the checks should pass
 linkerdViz:
   enabled: true


### PR DESCRIPTION
…ens on every sync, so it goes into a loop. This commit adds the necessary ignore differences specification to avoid an out of sync loop.