### PR TITLE
fix: grafana datasource value reference

### DIFF
--- a/chart/templates/grafana-dashboards.yaml
+++ b/chart/templates/grafana-dashboards.yaml
@@ -10,8 +10,8 @@ metadata:
   name: {{ printf "%s-%s" (include "platform-services.fullname" $) $dashboardName | trunc 53 | trimSuffix "-" }}-dashboard
   namespace: grafana
   labels:
-    {{- if $.Values.grafana.sidecar.dashboards.label }}
-    {{ $.Values.grafana.sidecar.dashboards.label }}: "1"
+    {{- if $.Values.grafana.values.sidecar.dashboards.label }}
+    {{ $.Values.grafana.values.sidecar.dashboards.label }}: "1"
     {{- end }}
     app: {{ template "platform-services.name" $ }}-grafana
 {{ include "platform-services.labels" $ | indent 4 }}

--- a/chart/templates/grafana-datasources.yaml
+++ b/chart/templates/grafana-datasources.yaml
@@ -5,8 +5,8 @@ metadata:
   name: {{ .Release.Name }}-grafana-datasources
   namespace: grafana
   labels:
-    {{- if $.Values.grafana.sidecar.datasources.label }}
-    {{ $.Values.grafana.sidecar.datasources.label }}: "1"
+    {{- if $.Values.grafana.values.sidecar.datasources.label }}
+    {{ $.Values.grafana.values.sidecar.datasources.label }}: "1"
     {{- end }}
     app: {{ template "platform-services.name" $ }}-grafana
 {{ include "platform-services.labels" $ | indent 4 }}


### PR DESCRIPTION
the value was determined by copying the contents of what exists in
kube-prometheus-stack, which didn't conform to the app of apps pattern,
oops.