### PR TITLE
feat: add grafana datasource authentication

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Create htpasswd values for Cortex. Append Grafana Datasource password to user de
 {{- if .Values.cortex.basicAuthSecret.enabled }}
 {{- .Values.cortex.basicAuthSecret.htpasswd }}
 {{- end }}
-{{- if and .Values.grafana.enabled }}
+{{- if .Values.grafana.enabled }}
 {{- if and (.Values.grafana.datasourceAuth) (.Values.grafana.deployDatasources) }}
 {{- htpasswd (required ".Values.grafana.datasourceAuth.cortex.username is required when using datasourceAuth" .Values.grafana.datasourceAuth.cortex.username) (required ".Values.grafana.datasourceAuth.cortex.password is required when using datasourceAuth" .Values.grafana.datasourceAuth.cortex.password) }}
 {{- end }}

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -60,3 +60,32 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create htpasswd values for Cortex. Append Grafana Datasource password to user defined htpasswd if enabled.
+*/}}
+{{- define "platform-services.cortexhtpasswd" -}}
+{{- if .Values.cortex.basicAuthSecret.enabled }}
+{{- .Values.cortex.basicAuthSecret.htpasswd }}
+{{- end }}
+{{- if and .Values.grafana.enabled }}
+{{- if and (.Values.grafana.datasourceAuth) (.Values.grafana.deployDatasources) }}
+{{- htpasswd (required ".Values.grafana.datasourceAuth.cortex.username is required when using datasourceAuth" .Values.grafana.datasourceAuth.cortex.username) (required ".Values.grafana.datasourceAuth.cortex.password is required when using datasourceAuth" .Values.grafana.datasourceAuth.cortex.password) }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Create htpasswd values for Loki. Append Grafana Datasource password to user defined htpasswd if enabled.
+*/}}
+{{- define "platform-services.lokihtpasswd" -}}
+{{- if .Values.loki.basicAuthSecret.enabled }}
+{{- .Values.loki.basicAuthSecret.htpasswd }}
+{{- end }}
+{{- if .Values.grafana.enabled }}
+{{- if and (.Values.grafana.datasourceAuth) (.Values.grafana.deployDatasources) }}
+{{- htpasswd (required ".Values.grafana.datasourceAuth.loki.username is required when using datasourceAuth" .Values.grafana.datasourceAuth.loki.username) (required ".Values.grafana.datasourceAuth.loki.password is required when using datasourceAuth" .Values.grafana.datasourceAuth.loki.password) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/chart/templates/cortex-auth.yaml
+++ b/chart/templates/cortex-auth.yaml
@@ -8,5 +8,5 @@ metadata:
 {{ include "platform-services.labels" $ | indent 6 }}
 type: Opaque
 data:
-  .htpasswd: {{ .Values.cortex.basicAuthSecret.htpasswd | b64enc | quote }}
+  .htpasswd: {{ include "platform-services.cortexhtpasswd" $ | b64enc | quote }}
 {{- end}}

--- a/chart/templates/grafana-datasources.yaml
+++ b/chart/templates/grafana-datasources.yaml
@@ -23,6 +23,14 @@ data:
       isDefault: true
       jsonData:
         timeInterval: 30s
+{{- if .Values.grafana.datasourceAuth }}
+{{- if .Values.grafana.datasourceAuth.cortex }}
+      basicAuth: true
+      basicAuthUser: $CORTEX_USERNAME
+      secureJsonData:
+        basicAuthPassword: $CORTEX_PASSWORD
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if .Values.loki.enabled }}
     - name: Loki
@@ -31,5 +39,13 @@ data:
       url:  http://loki-distributed-gateway.loki/
       access: proxy
       isDefault: false
+{{- if .Values.grafana.datasourceAuth }}
+{{- if .Values.grafana.datasourceAuth.loki }}
+      basicAuth: true
+      basicAuthUser: $LOKI_USERNAME
+      secureJsonData:
+        basicAuthPassword: $LOKI_PASSWORD
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/chart/templates/loki-auth.yaml
+++ b/chart/templates/loki-auth.yaml
@@ -8,5 +8,5 @@ metadata:
 {{ include "platform-services.labels" $ | indent 6 }}
 type: Opaque
 data:
-  .htpasswd: {{ .Values.loki.basicAuthSecret.htpasswd | b64enc | quote }}
+  .htpasswd: {{ include "platform-services.lokihtpasswd" $ | b64enc | quote }}
 {{- end}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -382,12 +382,20 @@ grafana:
         maxDuration: 3m
   deployDashboards: true
   deployDatasources: true
+  datasourceAuth:
+    cortex:
+      username: grafana
+      password:
+    loki:
+      username: grafana
+      password:
   values:
+    deploymentStrategy:
+      type: Recreate
+    envFromSecret: grafana-datasource-auth
     grafana.ini:
       server:
         root_url: https://replaceme
-    deploymentStrategy:
-      type: Recreate
     ingress:
       enabled: true
       annotations: {}


### PR DESCRIPTION
append to the htpassword file dynamically. require input values for
grafana's authentication to each service cortex/loki.

use envFromSecret to get authentication credentials into grafana's
datasource config.