### PR TITLE
fix: change loki release name to match helm chart

### DIFF
--- a/chart/templates/loki.yaml
+++ b/chart/templates/loki.yaml
@@ -13,7 +13,7 @@ spec:
     chart: loki-distributed
     targetRevision: {{ .Values.loki.targetRevision | quote }}
     helm:
-      releaseName: loki
+      releaseName: loki-distributed
       version: v3
       {{- with .Values.loki.values }}
       values: |


### PR DESCRIPTION
this should simplify the resource names from `loki-loki-distributed-*`
to just `loki-distributed-*`. some of the svc name references already
expect the latter.