### PR TITLE
fix: increase loki gateway's default client max body size

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -769,6 +769,9 @@ loki:
       basicAuth:
         enabled: true
         existingSecret: loki-auth
+      nginxConfig:
+        httpSnippet: |
+          client_max_body_size 10m;
     compactor:
       enabled: true
       resources: {}


### PR DESCRIPTION
otherwise, a lot of log queries result in http 413 errors