### PR TITLE
fix: remove configuration for cortex query scheduler

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -226,12 +226,6 @@ cortex:
       serviceMonitor:
         enabled: true
       resources: {}
-    query_scheduler:
-      enabled: true
-      replicas: 2
-      serviceMonitor:
-        enabled: true
-      resources: {}
     nginx:
       enabled: true
       replicas: 2


### PR DESCRIPTION
the component was added to the master branch of the helm chart, but
isn't actually in an official release yet. removing configuration to
prevent confusion around it.