### PR TITLE
fix: remove htpasswd generation for grafana datasource access

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -60,32 +60,3 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
-{{/*
-Create htpasswd values for Cortex. Append Grafana Datasource password to user defined htpasswd if enabled.
-*/}}
-{{- define "platform-services.cortexhtpasswd" -}}
-{{- if .Values.cortex.basicAuthSecret.enabled }}
-{{- .Values.cortex.basicAuthSecret.htpasswd }}
-{{- end }}
-{{- if .Values.grafana.enabled }}
-{{- if and (.Values.grafana.datasourceAuth) (.Values.grafana.deployDatasources) }}
-{{- htpasswd (required ".Values.grafana.datasourceAuth.cortex.username is required when using datasourceAuth" .Values.grafana.datasourceAuth.cortex.username) (required ".Values.grafana.datasourceAuth.cortex.password is required when using datasourceAuth" .Values.grafana.datasourceAuth.cortex.password) }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-
-{{/*
-Create htpasswd values for Loki. Append Grafana Datasource password to user defined htpasswd if enabled.
-*/}}
-{{- define "platform-services.lokihtpasswd" -}}
-{{- if .Values.loki.basicAuthSecret.enabled }}
-{{- .Values.loki.basicAuthSecret.htpasswd }}
-{{- end }}
-{{- if .Values.grafana.enabled }}
-{{- if and (.Values.grafana.datasourceAuth) (.Values.grafana.deployDatasources) }}
-{{- htpasswd (required ".Values.grafana.datasourceAuth.loki.username is required when using datasourceAuth" .Values.grafana.datasourceAuth.loki.username) (required ".Values.grafana.datasourceAuth.loki.password is required when using datasourceAuth" .Values.grafana.datasourceAuth.loki.password) }}
-{{- end }}
-{{- end }}
-{{- end }}

--- a/chart/templates/cortex-auth.yaml
+++ b/chart/templates/cortex-auth.yaml
@@ -8,5 +8,5 @@ metadata:
 {{ include "platform-services.labels" $ | indent 6 }}
 type: Opaque
 data:
-  .htpasswd: {{ include "platform-services.cortexhtpasswd" $ | b64enc | quote }}
+  .htpasswd: {{ .Values.cortex.basicAuthSecret.htpasswd | b64enc | quote }}
 {{- end}}

--- a/chart/templates/loki-auth.yaml
+++ b/chart/templates/loki-auth.yaml
@@ -8,5 +8,5 @@ metadata:
 {{ include "platform-services.labels" $ | indent 6 }}
 type: Opaque
 data:
-  .htpasswd: {{ include "platform-services.lokihtpasswd" $ | b64enc | quote }}
+  .htpasswd: {{ .Values.loki.basicAuthSecret.htpasswd | b64enc | quote }}
 {{- end}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -133,6 +133,7 @@ cortex:
     # generate htpasswd with: htpasswd -B -b -n username password
     # below contains examples, replace them
     htpasswd: |
+      grafana:$2y$05$iBw5CDTPmcz77EqpJeaRnOadjrelHCihXtkE1RRDV1LNOxYQYyTfK
       nonprod:$2y$05$cSeN/kud57vDkTULaweVreqM5k2GpTM950hy2NS5hi/0qaPvUdM4.
       prod:$2y$05$lghWCuEkcwKDVVlIzrfNzuwBa7HUUtUEbbfP0pLzZtbYhGOuOJJz6
       common:$2y$05$v.M9LmRpvgsQ2/clf9tJ9e5LqvI7CsklNsDbnrKZCvqwSuA.M24IC
@@ -597,6 +598,7 @@ loki:
     # generate htpasswd with: htpasswd -B -b -n username password
     # below contains examples, replace them
     htpasswd: |
+      grafana:$2y$05$ZqcZ4f64lALSya4XVrAw.ubf1FXEetQWFiPHguuXriRFVYKRktczu
       nonprod:$2y$05$uVfvMiek6GWobBbpYpWSr..uPx/1la7qSnmsA46Yk01vc.YuzoFWW
       prod:$2y$05$ZzXT9x/nyUqn8iRgG2IR0.kO20dJY73ql4oVXlHR8EMudM7ftYDZa
       common:$2y$05$oBoL5/JZEVwGYX.EZOqRBeO49LX/bGycWH5cmiDIcDH45RuCRpVhq


### PR DESCRIPTION
the automatic htpasswd generation causes a problem with argocd, it
regenerates the htpasswd value every time argocd attempts to sync.

this change will now require that a value for grafana's authentication to
datasources be generated and supplied in the htpasswd value.

added a bogus htpasswd value for grafana to serve as an example.