### PR TITLE
fix: upgrade helm chart versions that were removed from bitnami repo

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -77,7 +77,7 @@ clusterAutoscaler:
         name: "cluster-autoscaler"
 contour:
   enabled: true
-  targetRevision: "~7.4.6"
+  targetRevision: "~10.1.3"
   syncPolicy:
     automated:
       prune: true
@@ -299,7 +299,7 @@ cortex:
           enabled: true
 externalDns:
   enabled: true
-  targetRevision: "~6.1.6"
+  targetRevision: "~6.12.1"
   syncPolicy:
     automated:
       prune: true
@@ -719,7 +719,7 @@ loki:
       resources: {}
 metricsServer:
   enabled: true
-  targetRevision: "~5.11.3"
+  targetRevision: "~6.2.4"
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
bitnami removed versions that were more than 6 months old.

upgraded contour, external-dns, and metrics-server.