### PR TITLE
fix: metrics-server extra args

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -738,8 +738,8 @@ metricsServer:
     apiService:
       create: true # creates the v1beta1.metrics.k8s.io API service
     extraArgs:
-      kubelet-insecure-tls: ""
-      kubelet-preferred-address-types: InternalIP,ExternalIP,Hostname
+      - --kubelet-insecure-tls=true
+      - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
 prometheusBlackboxExporter:
   enabled: false
   targetRevision: "~5.6.0"


### PR DESCRIPTION
Turns out there was a breaking change, and I just missed that we were actually implementing the field that was changed.