### PR TITLE
fix: upgrade postgres bitnami chart version

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -349,7 +349,7 @@ fusionAuth:
         ingress.kubernetes.io/force-ssl-redirect: "true"
 fusionAuthPostgres:
   enabled: false
-  targetRevision: "~11.1.7"
+  targetRevision: "~12.1.5"
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
Didn't catch this change originally because I was working in the common cluster argocd. This is the same thing as https://github.com/catalystsquad/chart-platform-services/pull/52